### PR TITLE
Add book idea generator and quote categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,25 @@
-Quote Generator using Javascript
+Quote and Book Idea Generator using Javascript
 
 Notable features include:
+* Random quotes with optional category selection
+* Random book ideas with their own categories on a separate page
 
 -Pulls random quotes using an API
 ```javascript
 async function getQuote() {
     loading();
-    const proxyUrl = 'https://hidden-forest-89480.herokuapp.com/';
-    const apiUrl = 'http://api.forismatic.com/api/1.0/?method=getQuote&lang=en&format=json';
+    const tag = categorySelect.value;
+    const apiUrl = tag ? `https://api.quotable.io/random?tags=${tag}` : 'https://api.quotable.io/random';
     try {
-        const response = await fetch(proxyUrl + apiUrl);
+        const response = await fetch(apiUrl);
         const data = await response.json();
-        // If Author Is Blank, add 'Unknown'
-        if (data.quoteAuthor === '') {
-            authorText.innerText = 'Unknown';
-        } else {
-            authorText.innerText = data.quoteAuthor;
-        }
-        // Reduce Font Size for Long Quotes
-        if (data.quoteText.length > 120) {
+        authorText.innerText = data.author || 'Unknown';
+        if (data.content.length > 120) {
             quoteText.classList.add('long-quote');
         } else {
             quoteText.classList.remove('long-quote');
         }
-        quoteText.innerText = data.quoteText;
-        // Stop Loader, Show Quote
+        quoteText.innerText = data.content;
         complete();
     } catch (error) {
         getQuote();

--- a/books.html
+++ b/books.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Book Idea Generator</title>
+    <link rel="shortcut icon" type="image/png" href="favicon.png">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/css/all.min.css" integrity="sha512-1PKOgIY59xJ8Co8+NE6FZ+LOAZKjy+KY8iq0G4B3CyeY6wYHN3yt9PW0XpSriVlkMXe40PTKnXrLnZ9+fkDaog==" crossorigin="anonymous" />
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav>
+        <a href="index.html">Quotes</a>
+    </nav>
+    <div class="quote-container" id="idea-container">
+        <!-- Idea -->
+        <div class="quote-text">
+            <span id="idea"></span>
+        </div>
+        <!-- Category -->
+        <div class="category-select">
+            <label for="idea-category">Category:</label>
+            <select id="idea-category">
+                <option value="fiction">Fiction</option>
+                <option value="nonfiction">Non-fiction</option>
+                <option value="selfhelp">Self Help</option>
+            </select>
+        </div>
+        <!-- Buttons -->
+        <div class="button-container">
+            <button id="new-idea">New Idea</button>
+        </div>
+    </div>
+    <div class="loader" id="loader"></div>
+    <script src="books.js"></script>
+</body>
+</html>
+

--- a/books.js
+++ b/books.js
@@ -1,0 +1,47 @@
+const ideaText = document.getElementById('idea');
+const ideaBtn = document.getElementById('new-idea');
+const ideaCategory = document.getElementById('idea-category');
+const loader = document.getElementById('loader');
+
+const ideas = {
+    fiction: [
+        'A detective solves a mystery with the help of a ghost.',
+        'In a world where dreams can be traded, a girl sells hers to save her family.',
+        'Two strangers keep swapping bodies every time they fall asleep.'
+    ],
+    nonfiction: [
+        'A deep dive into the history of forgotten inventions.',
+        'Exploring the daily rituals of famous scientists.',
+        'A travelogue of remote islands around the world.'
+    ],
+    selfhelp: [
+        'How to organize your life using the power of tiny habits.',
+        'Finding creativity through simple morning routines.',
+        'A guide to building resilience during difficult times.'
+    ]
+};
+
+function loading() {
+    loader.hidden = false;
+    ideaText.hidden = true;
+}
+
+function complete() {
+    ideaText.hidden = false;
+    loader.hidden = true;
+}
+
+function getIdea() {
+    loading();
+    const category = ideaCategory.value;
+    const pool = ideas[category] || [];
+    const idea = pool[Math.floor(Math.random() * pool.length)];
+    ideaText.innerText = idea;
+    complete();
+}
+
+ideaBtn.addEventListener('click', getIdea);
+ideaCategory.addEventListener('change', getIdea);
+
+getIdea();
+

--- a/index.html
+++ b/index.html
@@ -9,6 +9,9 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <nav>
+        <a href="books.html">Book Ideas</a>
+    </nav>
     <div class="quote-container" id="quote-container">
         <!-- Quote -->
         <div class="quote-text">
@@ -18,6 +21,17 @@
         <!-- Author -->
         <div class="quote-author">
             <span id="author"></span>
+        </div>
+        <!-- Category -->
+        <div class="category-select">
+            <label for="quote-category">Category:</label>
+            <select id="quote-category">
+                <option value="">Random</option>
+                <option value="inspirational">Inspirational</option>
+                <option value="wisdom">Wisdom</option>
+                <option value="technology">Technology</option>
+                <option value="love">Love</option>
+            </select>
         </div>
         <!-- Buttons -->
         <div class="button-container">

--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@ const quoteText = document.getElementById('quote');
 const authorText = document.getElementById('author');
 const twitterBtn = document.getElementById('twitter');
 const newQuoteBtn = document.getElementById('new-quote');
+const categorySelect = document.getElementById('quote-category');
 const loader = document.getElementById('loader');
 
 // Show Loading
@@ -22,24 +23,20 @@ function complete() {
 // Get Quote From API
 async function getQuote() {
     loading();
-    const proxyUrl = 'https://hidden-forest-89480.herokuapp.com/';
-    const apiUrl = 'http://api.forismatic.com/api/1.0/?method=getQuote&lang=en&format=json';
+    const tag = categorySelect ? categorySelect.value : '';
+    const apiUrl = tag ? `https://api.quotable.io/random?tags=${tag}` : 'https://api.quotable.io/random';
     try {
-        const response = await fetch(proxyUrl + apiUrl);
+        const response = await fetch(apiUrl);
         const data = await response.json();
-        // If Author Is Blank, add 'Unknown'
-        if (data.quoteAuthor === '') {
-            authorText.innerText = 'Unknown';
-        } else {
-            authorText.innerText = data.quoteAuthor;
-        }
+        const author = data.author || 'Unknown';
+        authorText.innerText = author;
         // Reduce Font Size for Long Quotes
-        if (data.quoteText.length > 120) {
+        if (data.content.length > 120) {
             quoteText.classList.add('long-quote');
         } else {
             quoteText.classList.remove('long-quote');
         }
-        quoteText.innerText = data.quoteText;
+        quoteText.innerText = data.content;
         // Stop Loader, Show Quote
         complete();
     } catch (error) {
@@ -58,6 +55,9 @@ function tweetQuote() {
 // Event Listeners
 newQuoteBtn.addEventListener('click', getQuote);
 twitterBtn.addEventListener('click', tweetQuote);
+if (categorySelect) {
+    categorySelect.addEventListener('change', getQuote);
+}
 
 // On Load
 getQuote();

--- a/style.css
+++ b/style.css
@@ -96,7 +96,7 @@ button:active {
   }
 
 /* Media Query: Tablet or Smaller */
-@media screen and (max-width: 1000px) {S
+@media screen and (max-width: 1000px) {
     .quote-container {
         margin: auto 10px;
     }


### PR DESCRIPTION
## Summary
- allow selecting categories when generating a quote
- switch quote generator to quotable.io API
- add navigation link to a new Book Ideas page
- implement book idea generator with sample ideas
- fix minor CSS issue
- update README with new description and code sample

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6885810845108322afc504c7d703f618